### PR TITLE
Make DB config work the same everywhere

### DIFF
--- a/app/lib/db.js
+++ b/app/lib/db.js
@@ -3,6 +3,20 @@ const fs = require('fs');
 const streamsql = require('streamsql');
 const config = require('./config');
 
-module.exports = function getDB (key) {
-  return streamsql.connect(config(key));
+function getDbConfig (prefix) {
+  prefix += '_';
+  return {
+    driver:     config(prefix+'DRIVER', 'mysql'),
+    host:       config(prefix+'HOST', 'localhost'),
+    user:       config(prefix+'USER'),
+    password:   config(prefix+'PASSWORD'),
+    database:   config(prefix+'DATABASE')
+  }
+}
+
+function getDb (prefix) {
+  return streamsql.connect(getDbConfig(prefix));
 };
+
+module.exports.getDb = getDb;
+module.exports.getDbConfig = getDbConfig;

--- a/app/models/badge.js
+++ b/app/models/badge.js
@@ -1,7 +1,7 @@
-var getDB = require('../lib/db');
+var getDb = require('../lib/db').getDb;
 
 module.exports = function getBadgeModel (key) {
-  var db = getDB(key);
+  var db = getDb(key);
   try {
     return db.table('badge');
   }

--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -9,7 +9,7 @@ var migrate = require('db-migrate');
 var log = require('db-migrate/lib/log');
 var mysql = require('mysql');
 var migrations = require('../lib/migrations');
-var config = require('../app/lib/config');
+var db = require('../app/lib/db');
 
 process.on('uncaughtException', function(err) {
   log.error(err.stack);
@@ -76,7 +76,7 @@ function run() {
       break;
     case 'up':
     case 'down':
-      argv.config = config('DATABASE');
+      argv.config = db.getDbConfig('DATABASE');
       if(verbose) {
         log.info("Using settings:", argv.config);
       }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,9 @@
 var async = require('async');
 var migrations = require('../lib/migrations');
 var config = require('../app/lib/config');
-var connection = require('../app/lib/db')("TEST_DATABASE");
-const DB_CONFIG = config("TEST_DATABASE");
+var db = require('../app/lib/db');
+var connection = db.getDb("TEST_DATABASE");
+const DB_CONFIG = db.getDbConfig("TEST_DATABASE");
 
 exports.up = function up(options) {
   options = options || {};


### PR DESCRIPTION
Closes #52.

Added a helper to `db.js` to build the config object, and rely on that instead of `config-store` which currently only returns objects when config is read from a file.
