### PR TITLE
API Client renaming fixes

### DIFF
--- a/app/lib/openbadger.js
+++ b/app/lib/openbadger.js
@@ -1,6 +1,6 @@
 var config = require('./config');
 
-exports = module.exports = require('badgekit-issue-client')(
+exports = module.exports = require('badgekit-api-client')(
   config('OPENBADGER_URL'),
   config('OPENBADGER_SECRET')
 );

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express-persona-observer": "git+https://github.com/christensenep/express-persona-observer.git#multiple-buttons",
     "async": "~0.2.9",
     "mysql": "~2.0.0-rc1",
-    "badgekit-issue-client": "git+https://github.com/christensenep/badgekit-issue-client.git#initial-hacky-fixes"
+    "badgekit-api-client": "git+https://github.com/mozilla/badgekit-api-client.git"
   },
   "devDependencies": {
     "mocha": "~1.15.1",


### PR DESCRIPTION
Having renamed `badgekit-issue-client` to `badgekit-api-client`.
