### PR TITLE
Re-adding signup page

### DIFF
--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -1,0 +1,32 @@
+<section class="form-container clearfix">
+  <form class="sign-up-form js-sign-up-form" method="get" action="https://mozilla.us5.list-manage.com/subscribe/post-json?u=b7bf9f69069d22065249adfbe&id=7c543f060d&c=?">
+    <div class="form-fields left">
+      <div class="form-row left">
+        <span class="form-cell left form-col-1">Sign Up to Request Access to Private Beta</span>
+        <input class="form-cell left form-col-2 invalid-field js-email-expandable" type="email" name="EMAIL" placeholder="Enter your email" required="">
+      </div>
+      <div class="expandable-section js-expandable-section" class="hidden">
+        <div class="form-row left">
+          <input class="form-cell left form-col-1 invalid-field" type="text" name="ORGNAME" placeholder="Organization name" required="">
+          <input class="form-cell left form-col-2 invalid-field" type="text" name="CONTACTNAM" placeholder="Contact name" required="">
+        </div>
+        <div class="form-row left">
+          <input class="form-cell left form-col-1 invalid-field" type="text" name="ORGSIZE" placeholder="Organization size" required="">
+          <input class="form-cell left form-col-2 invalid-field" type="text" name="CONTACTPOS" placeholder="Contact position" required="">
+        </div>
+      </div>
+    </div>
+    <div class="button-container left">
+      <button class="form-cell btn" type="submit">Sign Up</button>
+      <div class="privacy js-privacy">
+        <input class="privacy-check js-privacy-check left" type="checkbox" required="">
+        <label class="privacy-text invalid-field" name="agree">I’m okay with Mozilla handling my info as explained in <a href="http://www.mozilla.org/en-US/privacy/policies/websites/" target="_blank">this Privacy Policy</a>
+        </label>
+      </div>
+    </div>
+  </form>
+  <div class="thanks-for-signup js-thanks-for-signup cb">
+    <h2>Thanks for signing up!</h2>
+    <p>We will contact you soon. In the meantime learn<br> more about <a href="http://openbadges.org/">Mozilla Open Badges</a></p>
+  </div>
+</section>


### PR DESCRIPTION
This just adds the signup.html file back to the repo.  It was removed when the signup form was removed from the landing page (for issue #421), but it is still needed when a user without access attempts to log on.  Right now we're getting 500's any time a user without access logs in.