### PR TITLE
Fix compatibility with Phusion Passenger

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -175,7 +175,7 @@ app.use(function (err, req, res, next) {
   });
 });
 
-if (!module.parent) {
+if (!module.parent || module.parent.isApplicationLoader) {
   const port = config('PORT', 3000);
 
   app.listen(port, function(err) {


### PR DESCRIPTION
BadgeKit calls `app.listen()` based on whether `module.parent` is null. But when BadgeKit is loaded from Passenger, `module.parent` is not null because Passenger does not run `index.js` directly, but `require()`s it from another file.

So in this commit we also check for `module.parent.isApplicationLoader` in the conditional. Passenger sets this flag, and it is proposed that other apps (e.g. PM2) could set this flag in the future too.

The `module.parent.isApplicationLoader` mechanism is used by for example the CompoundJS framework, which suffered from a similar problem. The discussion is here:
https://groups.google.com/forum/#!topic/phusion-passenger/6Cojr55tzfw

The mechanism is documented in the Passenger 4.0.34 changelog entry:
https://github.com/phusion/passenger/blob/release-5.0.6/CHANGELOG#L577-L590

This issue was originally reported here:
https://github.com/phusion/passenger/issues/1460
https://github.com/mozilla/openbadges-badgekit/issues/477