### PR TITLE
Use valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.39",
   "main": "app/index.js",
   "author": "Mozilla Open Badges http://openbadges.org",
-  "license": "MPL 2.0",
+  "license": "MPL-2.0",
   "readmeFilename": "README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm install` complains about invalid license identifier.

This PR replaces the identifier with this one:
https://spdx.org/licenses/MPL-2.0.html
