### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mysql": "~2.0.0-rc1",
     "badgekit-api-client": "git+https://github.com/mozilla/badgekit-api-client.git#milestones",
     "data-uri-to-buffer": "0.0.3",
-    "request": "~2.34.0"
+    "request": "~2.74.0"
   },
   "devDependencies": {
     "mocha": "~1.15.1",


### PR DESCRIPTION
openbadges-badgekit currently has a 41 vulnerable dependency paths, introducing 16 different types of known vulnerabilities.

This PR fixes 4 vulnerable dependency paths.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/mozilla/openbadges-badgekit) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)